### PR TITLE
use pktconn

### DIFF
--- a/.github/workflows/test_game.yml
+++ b/.github/workflows/test_game.yml
@@ -43,6 +43,6 @@ jobs:
           sleep 5
           goworld reload examples/test_game
           sleep 5
-          examples/test_client/test_client -N 200 -strict -duration 300
+          examples/test_client/test_client -N 200 -strict -duration 60
           sleep 1
           goworld stop examples/test_game

--- a/components/dispatcher/DispatcherService.go
+++ b/components/dispatcher/DispatcherService.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/xiaonanln/pktconn"
 
 	"net"
 
@@ -13,7 +14,6 @@ import (
 
 	"container/heap"
 
-	"github.com/pkg/errors"
 	"github.com/xiaonanln/goworld/engine/binutil"
 	"github.com/xiaonanln/goworld/engine/common"
 	"github.com/xiaonanln/goworld/engine/config"
@@ -38,10 +38,10 @@ func (edi *entityDispatchInfo) blockRPC(d time.Duration) {
 	}
 }
 
-func (edi *entityDispatchInfo) dispatchPacket(pkt *netutil.Packet) error {
+func (edi *entityDispatchInfo) dispatchPacket(pkt *netutil.Packet) {
 	if edi.blockUntilTime.IsZero() {
 		// most common case. handle it quickly
-		return dispatcherService.dispatchPacketToGame(edi.gameid, pkt)
+		dispatcherService.dispatchPacketToGame(edi.gameid, pkt)
 	}
 
 	// blockUntilTime is set, need to check if block should be released
@@ -49,17 +49,14 @@ func (edi *entityDispatchInfo) dispatchPacket(pkt *netutil.Packet) error {
 	if now.Before(edi.blockUntilTime) {
 		// keep blocking, just put the call to wait
 		if len(edi.pendingPacketQueue) < consts.ENTITY_PENDING_PACKET_QUEUE_MAX_LEN {
-			pkt.AddRefCount(1)
+			pkt.Retain()
 			edi.pendingPacketQueue = append(edi.pendingPacketQueue, pkt)
-			return nil
 		} else {
 			gwlog.Errorf("%s.dispatchPacket: packet queue too long, packet dropped", edi)
-			return errors.Errorf("%s: packet of entity dropped", dispatcherService)
 		}
 	} else {
 		// time to unblock
 		edi.unblock()
-		return nil
 	}
 }
 
@@ -116,7 +113,7 @@ func (gdi *gameDispatchInfo) isConnected() bool {
 	return gdi.clientProxy != nil
 }
 
-func (gdi *gameDispatchInfo) dispatchPacket(pkt *netutil.Packet) error {
+func (gdi *gameDispatchInfo) dispatchPacket(pkt *netutil.Packet) {
 	if gdi.checkBlocked() && gdi.clientProxy == nil {
 		// blocked from true -> false, and game is already disconnected before
 		// in this case, the game should be cleaned up
@@ -124,18 +121,17 @@ func (gdi *gameDispatchInfo) dispatchPacket(pkt *netutil.Packet) error {
 	}
 
 	if !gdi.isBlocked && gdi.clientProxy != nil {
-		return gdi.clientProxy.SendPacket(pkt)
+		gdi.clientProxy.SendPacket(pkt)
 	} else {
 		if len(gdi.pendingPacketQueue) < consts.GAME_PENDING_PACKET_QUEUE_MAX_LEN {
 			gdi.pendingPacketQueue = append(gdi.pendingPacketQueue, pkt)
-			pkt.AddRefCount(1)
+			pkt.Retain()
 
 			if len(gdi.pendingPacketQueue)%1 == 0 {
 				gwlog.Warnf("game %d pending packet count = %d, blocked = %v, clientProxy = %s", gdi.gameid, len(gdi.pendingPacketQueue), gdi.isBlocked, gdi.clientProxy)
 			}
-			return nil
 		} else {
-			return errors.Errorf("packet to game %d is dropped", gdi.gameid)
+			gwlog.Errorf("packet to game %d is dropped", gdi.gameid)
 		}
 	}
 }
@@ -168,11 +164,6 @@ func (gdi *gameDispatchInfo) clearPendingPackets() {
 	}
 }
 
-type dispatcherMessage struct {
-	dcp *dispatcherClientProxy
-	proto.Message
-}
-
 // DispatcherService implements the dispatcher service
 type DispatcherService struct {
 	dispid                uint16
@@ -180,7 +171,7 @@ type DispatcherService struct {
 	games                 map[uint16]*gameDispatchInfo
 	bootGames             []uint16
 	gates                 map[uint16]*dispatcherClientProxy
-	messageQueue          chan dispatcherMessage
+	messageQueue          chan *pktconn.Packet
 	entityDispatchInfos   map[common.EntityID]*entityDispatchInfo
 	kvregRegisterMap      map[string]string
 	entitySyncInfosToGame map[uint16]*netutil.Packet // cache entity sync infos to gates
@@ -195,7 +186,7 @@ func newDispatcherService(dispid uint16) *DispatcherService {
 	ds := &DispatcherService{
 		dispid:                dispid,
 		config:                cfg,
-		messageQueue:          make(chan dispatcherMessage, consts.DISPATCHER_SERVICE_PACKET_QUEUE_SIZE),
+		messageQueue:          make(chan *pktconn.Packet, consts.DISPATCHER_SERVICE_PACKET_QUEUE_SIZE),
 		games:                 map[uint16]*gameDispatchInfo{},
 		gates:                 map[uint16]*dispatcherClientProxy{},
 		entityDispatchInfos:   map[common.EntityID]*entityDispatchInfo{},
@@ -214,10 +205,12 @@ func newDispatcherService(dispid uint16) *DispatcherService {
 func (service *DispatcherService) messageLoop() {
 	for {
 		select {
-		case msg := <-service.messageQueue:
-			dcp := msg.dcp
-			msgtype := msg.MsgType
-			pkt := msg.Packet
+		case _pkt := <-service.messageQueue:
+			pkt := (*netutil.Packet)(_pkt)
+			dcp := pkt.Src.Tag.(*dispatcherClientProxy)
+
+			msgtype := proto.MsgType(pkt.ReadUint16())
+
 			if msgtype >= proto.MT_REDIRECT_TO_GATEPROXY_MSG_TYPE_START && msgtype <= proto.MT_REDIRECT_TO_GATEPROXY_MSG_TYPE_STOP {
 				service.handleDoSomethingOnSpecifiedClient(dcp, pkt)
 			} else {
@@ -512,12 +505,12 @@ func (service *DispatcherService) connectedGameClientsNum() int {
 	return num
 }
 
-func (service *DispatcherService) dispatchPacketToGame(gameid uint16, pkt *netutil.Packet) error {
+func (service *DispatcherService) dispatchPacketToGame(gameid uint16, pkt *netutil.Packet) {
 	gdi := service.games[gameid]
 	if gdi != nil {
-		return gdi.dispatchPacket(pkt)
+		gdi.dispatchPacket(pkt)
 	} else {
-		return errors.Errorf("%s: dispatchPacketToGame: game%d is not found", service, gameid)
+		gwlog.Errorf("%s: dispatchPacketToGame: game%d is not found", service, gameid)
 	}
 }
 
@@ -746,16 +739,6 @@ func (service *DispatcherService) handleKvregRegister(dcp *dispatcherClientProxy
 		gwlog.Infof("%s: kvreg register %s = %s, force %v, curinfo=%s, register failed", service, srvid, srvinfo, force, curinfo)
 	}
 }
-
-//func (service *DispatcherService) handleServiceDown(gameid uint16, serviceName string, eid common.EntityID) {
-//	gwlog.Warnf("%s: service %s: entity %s is down!", service, serviceName, eid)
-//	pkt := netutil.NewPacket()
-//	pkt.AppendUint16(proto.MT_UNDECLARE_SERVICE)
-//	pkt.AppendEntityID(eid)
-//	pkt.AppendVarStr(serviceName)
-//	service.broadcastToGamesExcept(pkt, gameid)
-//	pkt.Release()
-//}
 
 func (service *DispatcherService) handleCallEntityMethod(dcp *dispatcherClientProxy, pkt *netutil.Packet) {
 	entityID := pkt.ReadEntityID()

--- a/components/game/game.go
+++ b/components/game/game.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"flag"
+	"github.com/xiaonanln/pktconn"
 
 	"math/rand"
 	"time"
@@ -31,9 +32,7 @@ import (
 	"github.com/xiaonanln/goworld/engine/entity"
 	"github.com/xiaonanln/goworld/engine/gwlog"
 	"github.com/xiaonanln/goworld/engine/kvdb"
-	"github.com/xiaonanln/goworld/engine/netutil"
 	"github.com/xiaonanln/goworld/engine/post"
-	"github.com/xiaonanln/goworld/engine/proto"
 	"github.com/xiaonanln/goworld/engine/service"
 	"github.com/xiaonanln/goworld/engine/storage"
 )
@@ -218,13 +217,8 @@ func waitEntityStorageFinish() {
 type _GameDispatcherClientDelegate struct {
 }
 
-var lastWarnGateServiceQueueLen = 0
-
-func (delegate *_GameDispatcherClientDelegate) HandleDispatcherClientPacket(msgtype proto.MsgType, packet *netutil.Packet) {
-	gameService.packetQueue <- proto.Message{ // may block the dispatcher client routine
-		MsgType: msgtype,
-		Packet:  packet,
-	}
+func (delegate *_GameDispatcherClientDelegate) GetDispatcherClientPacketQueue() chan *pktconn.Packet {
+	return gameService.packetQueue
 }
 
 func (delegate *_GameDispatcherClientDelegate) HandleDispatcherClientDisconnect() {

--- a/components/gate/ClientProxy.go
+++ b/components/gate/ClientProxy.go
@@ -9,7 +9,6 @@ import (
 	"github.com/xiaonanln/goworld/engine/common"
 	"github.com/xiaonanln/goworld/engine/config"
 	"github.com/xiaonanln/goworld/engine/consts"
-	"github.com/xiaonanln/goworld/engine/gwioutil"
 	"github.com/xiaonanln/goworld/engine/gwlog"
 	"github.com/xiaonanln/goworld/engine/netutil"
 	"github.com/xiaonanln/goworld/engine/post"
@@ -43,25 +42,17 @@ func newClientProxy(_conn net.Conn, cfg *config.GateConfig) *ClientProxy {
 		conn = netconnutil.NewSnappyConn(conn)
 	}
 	conn = netconnutil.NewBufferedConn(conn, consts.BUFFERED_READ_BUFFSIZE, consts.BUFFERED_WRITE_BUFFSIZE)
-	gwc := proto.NewGoWorldConnection(conn)
-	return &ClientProxy{
-		GoWorldConnection: gwc,
-		clientid:          common.GenClientID(), // each client has its unique clientid
-		filterProps:       map[string]string{},
+	clientProxy := &ClientProxy{
+		clientid:    common.GenClientID(), // each client has its unique clientid
+		filterProps: map[string]string{},
 	}
+	clientProxy.GoWorldConnection = proto.NewGoWorldConnection(conn, clientProxy)
+	return clientProxy
 }
 
 func (cp *ClientProxy) String() string {
 	return fmt.Sprintf("ClientProxy<%s@%s>", cp.clientid, cp.RemoteAddr())
 }
-
-//func (cp *ClientProxy) SendPacket(packet *netutil.Packet) error {
-//	err := cp.GoWorldConnection.SendPacket(packet)
-//	if err != nil {
-//		return err
-//	}
-//	return cp.Flush("ClientProxy")
-//}
 
 func (cp *ClientProxy) serve() {
 	defer func() {
@@ -78,20 +69,8 @@ func (cp *ClientProxy) serve() {
 		}
 	}()
 
-	cp.SetAutoFlush(consts.CLIENT_PROXY_WRITE_FLUSH_INTERVAL)
-	//cp.SendSetClientClientID(cp.cp) // set the cp on the client side
-
-	for {
-		var msgtype proto.MsgType
-		pkt, err := cp.Recv(&msgtype)
-		if pkt != nil {
-			gateService.clientPacketQueue <- clientProxyMessage{cp, proto.Message{msgtype, pkt}}
-		} else if err != nil && !gwioutil.IsTimeoutError(err) {
-			if netutil.IsConnectionError(err) {
-				break
-			} else {
-				panic(err)
-			}
-		}
+	err := cp.RecvChan(gateService.clientPacketQueue)
+	if err != nil {
+		gwlog.Panic(err)
 	}
 }

--- a/components/gate/GateService.go
+++ b/components/gate/GateService.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/xiaonanln/pktconn"
 	"time"
 
 	"golang.org/x/net/websocket"
@@ -28,17 +29,12 @@ import (
 	"github.com/xtaci/kcp-go"
 )
 
-type clientProxyMessage struct {
-	cp  *ClientProxy
-	msg proto.Message
-}
-
 // GateService implements the gate service logic
 type GateService struct {
 	listenAddr                  string
 	clientProxies               map[common.ClientID]*ClientProxy
-	dispatcherClientPacketQueue chan proto.Message
-	clientPacketQueue           chan clientProxyMessage
+	dispatcherClientPacketQueue chan *pktconn.Packet
+	clientPacketQueue           chan *pktconn.Packet
 	ticker                      <-chan time.Time
 
 	filterTrees             map[string]*_FilterTree
@@ -63,8 +59,8 @@ func newGateService() *GateService {
 	return &GateService{
 		//dispatcherClientPacketQueue: make(chan packetQueueItem, consts.DISPATCHER_CLIENT_PACKET_QUEUE_SIZE),
 		clientProxies:               map[common.ClientID]*ClientProxy{},
-		dispatcherClientPacketQueue: make(chan proto.Message, consts.GATE_SERVICE_PACKET_QUEUE_SIZE),
-		clientPacketQueue:           make(chan clientProxyMessage, consts.GATE_SERVICE_PACKET_QUEUE_SIZE),
+		dispatcherClientPacketQueue: make(chan *pktconn.Packet, consts.GATE_SERVICE_PACKET_QUEUE_SIZE),
+		clientPacketQueue:           make(chan *pktconn.Packet, consts.GATE_SERVICE_PACKET_QUEUE_SIZE),
 		ticker:                      time.Tick(consts.GATE_SERVICE_TICK_INTERVAL),
 		filterTrees:                 map[string]*_FilterTree{},
 		pendingSyncPackets:          pendingSyncPackets,
@@ -236,9 +232,14 @@ func (gs *GateService) onClientProxyClose(cp *ClientProxy) {
 	}
 }
 
-// HandleDispatcherClientPacket handles packets received by dispatcher client
-func (gs *GateService) handleClientProxyPacket(cp *ClientProxy, msgtype proto.MsgType, pkt *netutil.Packet) {
+// GetDispatcherClientPacketQueue handles packets received by dispatcher client
+func (gs *GateService) handleClientProxyPacket(_pkt *pktconn.Packet) {
+	pkt := (*netutil.Packet)(_pkt)
+	cp := pkt.Src.Tag.(*ClientProxy)
 	cp.heartbeatTime = time.Now()
+
+	msgtype := proto.MsgType(pkt.ReadUint16())
+
 	switch msgtype {
 	case proto.MT_SYNC_POSITION_YAW_FROM_CLIENT:
 		gs.handleSyncPositionYawFromClient(pkt)
@@ -254,7 +255,10 @@ func (gs *GateService) handleClientProxyPacket(cp *ClientProxy, msgtype proto.Ms
 
 }
 
-func (gs *GateService) handleDispatcherClientPacket(msgtype proto.MsgType, packet *netutil.Packet) {
+func (gs *GateService) handleDispatcherClientPacket(_pkt *pktconn.Packet) {
+	packet := (*netutil.Packet)(_pkt)
+	msgtype := proto.MsgType(packet.ReadUint16())
+
 	if consts.DEBUG_PACKETS {
 		gwlog.Debugf("%s.handleDispatcherClientPacket: msgtype=%v, packet(%d)=%v", gs, msgtype, packet.GetPayloadLen(), packet.Payload())
 	}
@@ -427,16 +431,16 @@ func (gs *GateService) tryFlushPendingSyncPackets() {
 func (gs *GateService) mainRoutine() {
 	for {
 		select {
-		case item := <-gs.clientPacketQueue:
+		case pkt := <-gs.clientPacketQueue:
 			op := opmon.StartOperation("GateServiceHandlePacket")
-			gs.handleClientProxyPacket(item.cp, item.msg.MsgType, item.msg.Packet)
+			gs.handleClientProxyPacket(pkt)
 			op.Finish(time.Millisecond * 100)
-			item.msg.Packet.Release()
-		case item := <-gs.dispatcherClientPacketQueue:
+			pkt.Release()
+		case pkt := <-gs.dispatcherClientPacketQueue:
 			op := opmon.StartOperation("GateServiceHandlePacket")
-			gs.handleDispatcherClientPacket(item.MsgType, item.Packet)
+			gs.handleDispatcherClientPacket(pkt)
 			op.Finish(time.Millisecond * 100)
-			item.Packet.Release()
+			pkt.Release()
 			break
 		case <-gs.ticker:
 			gs.tryFlushPendingSyncPackets()

--- a/components/gate/gate.go
+++ b/components/gate/gate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"github.com/xiaonanln/pktconn"
 
 	"math/rand"
 	"time"
@@ -26,9 +27,7 @@ import (
 	"github.com/xiaonanln/goworld/engine/dispatchercluster"
 	"github.com/xiaonanln/goworld/engine/dispatchercluster/dispatcherclient"
 	"github.com/xiaonanln/goworld/engine/gwlog"
-	"github.com/xiaonanln/goworld/engine/netutil"
 	"github.com/xiaonanln/goworld/engine/post"
-	"github.com/xiaonanln/goworld/engine/proto"
 )
 
 var (
@@ -131,8 +130,8 @@ func setupSignals() {
 type gateDispatcherClientDelegate struct {
 }
 
-func (delegate *gateDispatcherClientDelegate) HandleDispatcherClientPacket(msgtype proto.MsgType, packet *netutil.Packet) {
-	gateService.dispatcherClientPacketQueue <- proto.Message{msgtype, packet}
+func (delegate *gateDispatcherClientDelegate) GetDispatcherClientPacketQueue() chan *pktconn.Packet {
+	return gateService.dispatcherClientPacketQueue
 }
 
 func (delegate *gateDispatcherClientDelegate) HandleDispatcherClientDisconnect() {

--- a/engine/consts/consts.go
+++ b/engine/consts/consts.go
@@ -15,7 +15,7 @@ const (
 	// BUFFERED_WRITE_BUFFSIZE is the write buffer size for BufferedWriteConnection
 	BUFFERED_WRITE_BUFFSIZE = 16384
 
-	// For Packets Send & Recv
+	// For Packets Send & RecvChan
 	// PACKET_PAYLOAD_LEN_COMPRESS_THRESHOLD is the minimal packet payload length that should be compressed
 	PACKET_PAYLOAD_LEN_COMPRESS_THRESHOLD = 512
 
@@ -34,10 +34,6 @@ const (
 	DISPATCHER_SERVICE_PACKET_QUEUE_SIZE = 10000
 	// DISPATCHER_SERVICE_TICK_INTERVAL is the tick interval for dispatcher service's main routine.
 	DISPATCHER_SERVICE_TICK_INTERVAL = time.Millisecond * 5 // server tick interval => affect timer resolution
-	// DISPATCHER_CLIENT_PROXY_WRITE_FLUSH_INTERVAL is the flush interval for client proxy. Smaller interval costs more CPU but dispatches patckets sooner
-	DISPATCHER_CLIENT_PROXY_WRITE_FLUSH_INTERVAL = 5 * time.Millisecond
-	// DISPATCHER_CLIENT_FLUSH_INTERVAL is the flush interval for dispatcher clients (game -> dispatcher)
-	DISPATCHER_CLIENT_FLUSH_INTERVAL = 5 * time.Millisecond
 
 	// For Game Service
 	// GAME_SERVICE_PACKET_QUEUE_SIZE is the max packet queue length for game service

--- a/engine/dispatchercluster/dispatcherclient/DispatcherClient.go
+++ b/engine/dispatchercluster/dispatcherclient/DispatcherClient.go
@@ -25,19 +25,20 @@ type DispatcherClient struct {
 }
 
 func newDispatcherClient(dctype DispatcherClientType, conn net.Conn, isReconnect bool, isRestoreGame bool) *DispatcherClient {
-	conn = netconnutil.NewNoTempErrorConn(conn)
-	gwc := proto.NewGoWorldConnection(netconnutil.NewBufferedConn(conn, consts.BUFFERED_READ_BUFFSIZE, consts.BUFFERED_WRITE_BUFFSIZE))
 	if dctype != GameDispatcherClientType && dctype != GateDispatcherClientType {
 		gwlog.Fatalf("invalid dispatcher client type: %v", dctype)
 	}
 
+	conn = netconnutil.NewNoTempErrorConn(conn)
+
 	dc := &DispatcherClient{
-		GoWorldConnection: gwc,
-		dctype:            dctype,
-		isReconnect:       isReconnect,
-		isRestoreGame:     isRestoreGame,
+		dctype:        dctype,
+		isReconnect:   isReconnect,
+		isRestoreGame: isRestoreGame,
 	}
-	dc.SetAutoFlush(consts.DISPATCHER_CLIENT_FLUSH_INTERVAL)
+
+	dc.GoWorldConnection = proto.NewGoWorldConnection(netconnutil.NewBufferedConn(conn, consts.BUFFERED_READ_BUFFSIZE, consts.BUFFERED_WRITE_BUFFSIZE), dc)
+
 	return dc
 }
 

--- a/engine/dispatchercluster/dispatchercluster.go
+++ b/engine/dispatchercluster/dispatchercluster.go
@@ -36,16 +36,16 @@ func Initialize(_gid uint16, dctype dispatcherclient.DispatcherClientType, isRes
 	}
 }
 
-func SendNotifyDestroyEntity(id common.EntityID) error {
-	return SelectByEntityID(id).SendNotifyDestroyEntity(id)
+func SendNotifyDestroyEntity(id common.EntityID) {
+	SelectByEntityID(id).SendNotifyDestroyEntity(id)
 }
 
-func SendMigrateRequest(entityID common.EntityID, spaceID common.EntityID, spaceGameID uint16) error {
-	return SelectByEntityID(entityID).SendMigrateRequest(entityID, spaceID, spaceGameID)
+func SendMigrateRequest(entityID common.EntityID, spaceID common.EntityID, spaceGameID uint16) {
+	SelectByEntityID(entityID).SendMigrateRequest(entityID, spaceID, spaceGameID)
 }
 
-func SendRealMigrate(eid common.EntityID, targetGame uint16, data []byte) error {
-	return SelectByEntityID(eid).SendRealMigrate(eid, targetGame, data)
+func SendRealMigrate(eid common.EntityID, targetGame uint16, data []byte) {
+	SelectByEntityID(eid).SendRealMigrate(eid, targetGame, data)
 }
 func SendCallFilterClientProxies(op proto.FilterClientsOpType, key, val string, method string, args []interface{}) {
 	pkt := proto.AllocCallFilterClientProxiesPacket(op, key, val, method, args)
@@ -60,25 +60,24 @@ func broadcast(packet *netutil.Packet) {
 	}
 }
 
-func SendNotifyCreateEntity(id common.EntityID) error {
+func SendNotifyCreateEntity(id common.EntityID) {
 	if gid != 0 {
-		return SelectByEntityID(id).SendNotifyCreateEntity(id)
+		SelectByEntityID(id).SendNotifyCreateEntity(id)
 	} else {
 		// goes here when creating nil space or restoring freezed entities
-		return nil
 	}
 }
 
-func SendLoadEntityAnywhere(typeName string, entityID common.EntityID) error {
-	return SelectByEntityID(entityID).SendLoadEntitySomewhere(typeName, entityID, 0)
+func SendLoadEntityAnywhere(typeName string, entityID common.EntityID) {
+	SelectByEntityID(entityID).SendLoadEntitySomewhere(typeName, entityID, 0)
 }
 
-func SendLoadEntityOnGame(typeName string, entityID common.EntityID, gameid uint16) error {
-	return SelectByEntityID(entityID).SendLoadEntitySomewhere(typeName, entityID, gameid)
+func SendLoadEntityOnGame(typeName string, entityID common.EntityID, gameid uint16) {
+	SelectByEntityID(entityID).SendLoadEntitySomewhere(typeName, entityID, gameid)
 }
 
-func SendCreateEntitySomewhere(gameid uint16, entityid common.EntityID, typeName string, data map[string]interface{}) error {
-	return SelectByEntityID(entityid).SendCreateEntitySomewhere(gameid, entityid, typeName, data)
+func SendCreateEntitySomewhere(gameid uint16, entityid common.EntityID, typeName string, data map[string]interface{}) {
+	SelectByEntityID(entityid).SendCreateEntitySomewhere(gameid, entityid, typeName, data)
 }
 
 func SendGameLBCInfo(lbcinfo proto.GameLBCInfo) {

--- a/engine/netutil/Packet.go
+++ b/engine/netutil/Packet.go
@@ -2,276 +2,80 @@ package netutil
 
 import (
 	"encoding/binary"
+	"github.com/xiaonanln/pktconn"
 
 	"unsafe"
 
-	"sync/atomic"
-
-	"sync"
-
 	"github.com/xiaonanln/goworld/engine/common"
-	"github.com/xiaonanln/goworld/engine/consts"
 	"github.com/xiaonanln/goworld/engine/gwlog"
 )
 
-const (
-	_MIN_PAYLOAD_CAP = 128
-	_CAP_GROW_SHIFT  = uint(2)
-)
-
-var (
-	packetEndian               = binary.LittleEndian
-	predefinePayloadCapacities []uint32
-
-	debugInfo struct {
-		NewCount     int64
-		AllocCount   int64
-		ReleaseCount int64
-	}
-
-	packetBufferPools = map[uint32]*sync.Pool{}
-	packetPool        = sync.Pool{
-		New: func() interface{} {
-			p := &Packet{}
-			p.bytes = p.initialBytes[:]
-
-			if consts.DEBUG_PACKET_ALLOC {
-				atomic.AddInt64(&debugInfo.NewCount, 1)
-				gwlog.Infof("DEBUG PACKETS: ALLOC=%d, RELEASE=%d, NEW=%d",
-					atomic.LoadInt64(&debugInfo.AllocCount),
-					atomic.LoadInt64(&debugInfo.ReleaseCount),
-					atomic.LoadInt64(&debugInfo.NewCount))
-			}
-			return p
-		},
-	}
-)
-
-func init() {
-
-	if _MIN_PAYLOAD_CAP >= consts.PACKET_PAYLOAD_LEN_COMPRESS_THRESHOLD {
-		gwlog.Fatalf("_MIN_PAYLOAD_CAP should be smaller than PACKET_PAYLOAD_LEN_COMPRESS_THRESHOLD")
-	}
-
-	payloadCap := uint32(_MIN_PAYLOAD_CAP) << _CAP_GROW_SHIFT
-	for payloadCap < _MAX_PAYLOAD_LENGTH {
-		predefinePayloadCapacities = append(predefinePayloadCapacities, payloadCap)
-		payloadCap <<= _CAP_GROW_SHIFT
-	}
-	predefinePayloadCapacities = append(predefinePayloadCapacities, _MAX_PAYLOAD_LENGTH)
-
-	for _, payloadCap := range predefinePayloadCapacities {
-		payloadCap := payloadCap
-		packetBufferPools[payloadCap] = &sync.Pool{
-			New: func() interface{} {
-				return make([]byte, _PREPAYLOAD_SIZE+payloadCap)
-			},
-		}
-	}
-}
-
-func getPayloadCapOfPayloadLen(payloadLen uint32) uint32 {
-	for _, payloadCap := range predefinePayloadCapacities {
-		if payloadCap >= payloadLen {
-			return payloadCap
-		}
-	}
-	return _MAX_PAYLOAD_LENGTH
-}
-
 // Packet is a packet for sending data
-type Packet struct {
-	readCursor uint32
-
-	refcount     int64
-	bytes        []byte
-	initialBytes [_PREPAYLOAD_SIZE + _MIN_PAYLOAD_CAP]byte
-}
-
-func allocPacket() *Packet {
-	pkt := packetPool.Get().(*Packet)
-	pkt.refcount = 1
-
-	if consts.DEBUG_PACKET_ALLOC {
-		atomic.AddInt64(&debugInfo.AllocCount, 1)
-	}
-
-	if pkt.GetPayloadLen() != 0 {
-		gwlog.Panicf("allocPacket: payload should be 0, but is %d", pkt.GetPayloadLen())
-	}
-
-	return pkt
-}
+type Packet pktconn.Packet
 
 // NewPacket allocates a new packet
 func NewPacket() *Packet {
-	return allocPacket()
-}
-
-func (p *Packet) AssureCapacity(need uint32) {
-	requireCap := p.GetPayloadLen() + need
-	oldCap := p.PayloadCap()
-
-	if requireCap <= oldCap { // most case
-		return
-	}
-
-	// try to find the proper capacity for the need bytes
-	resizeToCap := getPayloadCapOfPayloadLen(requireCap)
-
-	buffer := packetBufferPools[resizeToCap].Get().([]byte)
-	if len(buffer) != int(resizeToCap+_SIZE_FIELD_SIZE) {
-		gwlog.Panicf("buffer size should be %d, but is %d", resizeToCap, len(buffer))
-	}
-	copy(buffer, p.data())
-	oldPayloadCap := p.PayloadCap()
-	oldBytes := p.bytes
-	p.bytes = buffer
-
-	if oldPayloadCap > _MIN_PAYLOAD_CAP {
-		// release old bytes
-		packetBufferPools[oldPayloadCap].Put(oldBytes)
-	}
-}
-
-// AddRefCount adds reference count of packet
-func (p *Packet) AddRefCount(add int64) {
-	atomic.AddInt64(&p.refcount, add)
+	return (*Packet)(pktconn.NewPacket())
 }
 
 // Payload returns the total payload of packet
 func (p *Packet) Payload() []byte {
-	return p.bytes[_PREPAYLOAD_SIZE : _PREPAYLOAD_SIZE+p.GetPayloadLen()]
-}
-
-// UnwrittenPayload returns the unwritten payload, which is the left payload capacity
-func (p *Packet) UnwrittenPayload() []byte {
-	payloadLen := p.GetPayloadLen()
-	return p.bytes[_PREPAYLOAD_SIZE+payloadLen:]
-}
-
-func (p *Packet) TotalPayload() []byte {
-	return p.bytes[_PREPAYLOAD_SIZE:]
+	return (*pktconn.Packet)(p).Payload()
 }
 
 // UnreadPayload returns the unread payload
 func (p *Packet) UnreadPayload() []byte {
-	pos := p.readCursor + _PREPAYLOAD_SIZE
-	payloadEnd := _PREPAYLOAD_SIZE + p.GetPayloadLen()
-	return p.bytes[pos:payloadEnd]
+	return (*pktconn.Packet)(p).UnreadPayload()
 }
 
 // HasUnreadPayload returns if all payload is read
 func (p *Packet) HasUnreadPayload() bool {
-	pos := p.readCursor + _PREPAYLOAD_SIZE
-	plen := p.GetPayloadLen()
-	return pos < plen
-}
-
-func (p *Packet) data() []byte {
-	return p.bytes[0 : _PREPAYLOAD_SIZE+p.GetPayloadLen()]
-}
-
-// PayloadCap returns the current payload capacity
-func (p *Packet) PayloadCap() uint32 {
-	return uint32(len(p.bytes) - _PREPAYLOAD_SIZE)
+	return (*pktconn.Packet)(p).HasUnreadPayload()
 }
 
 // Release releases the packet to packet pool
 func (p *Packet) Release() {
-	refcount := atomic.AddInt64(&p.refcount, -1)
-
-	if refcount == 0 {
-		payloadCap := p.PayloadCap()
-		if payloadCap > _MIN_PAYLOAD_CAP {
-			buffer := p.bytes
-			p.bytes = p.initialBytes[:]
-			packetBufferPools[payloadCap].Put(buffer) // reclaim the buffer
-		}
-
-		p.readCursor = 0
-		p.SetPayloadLen(0)
-		packetPool.Put(p)
-
-		if consts.DEBUG_PACKET_ALLOC {
-			atomic.AddInt64(&debugInfo.ReleaseCount, 1)
-		}
-	} else if refcount < 0 {
-		gwlog.Panicf("releasing packet with refcount=%d", p.refcount)
-	}
+	(*pktconn.Packet)(p).Release()
 }
 
 // ClearPayload clears packet payload
 func (p *Packet) ClearPayload() {
-	p.readCursor = 0
-	p.SetPayloadLen(0)
+	(*pktconn.Packet)(p).ClearPayload()
 }
 
 // AppendByte appends one byte to the end of payload
 func (p *Packet) AppendByte(b byte) {
-	p.AssureCapacity(1)
-	p.bytes[_PREPAYLOAD_SIZE+p.GetPayloadLen()] = b
-	*(*uint32)(unsafe.Pointer(&p.bytes[0])) += 1
+	(*pktconn.Packet)(p).WriteOneByte(b)
 }
 
 // ReadOneByte reads one byte from the beginning
 func (p *Packet) ReadOneByte() (v byte) {
-	pos := p.readCursor + _PREPAYLOAD_SIZE
-	v = p.bytes[pos]
-	p.readCursor += 1
-	return
+	return (*pktconn.Packet)(p).ReadOneByte()
 }
 
 // AppendBool appends one byte 1/0 to the end of payload
 func (p *Packet) AppendBool(b bool) {
-	if b {
-		p.AppendByte(1)
-	} else {
-		p.AppendByte(0)
-	}
+	(*pktconn.Packet)(p).WriteBool(b)
 }
 
 // ReadBool reads one byte 1/0 from the beginning of unread payload
 func (p *Packet) ReadBool() (v bool) {
-	return p.ReadOneByte() != 0
+	return (*pktconn.Packet)(p).ReadBool()
 }
 
 // AppendUint16 appends one uint16 to the end of payload
 func (p *Packet) AppendUint16(v uint16) {
-	p.AssureCapacity(2)
-	payloadEnd := _PREPAYLOAD_SIZE + p.GetPayloadLen()
-	packetEndian.PutUint16(p.bytes[payloadEnd:payloadEnd+2], v)
-	*(*uint32)(unsafe.Pointer(&p.bytes[0])) += 2
+	(*pktconn.Packet)(p).WriteUint16(v)
 }
 
 // AppendUint32 appends one uint32 to the end of payload
 func (p *Packet) AppendUint32(v uint32) {
-	p.AssureCapacity(4)
-	payloadEnd := _PREPAYLOAD_SIZE + p.GetPayloadLen()
-	packetEndian.PutUint32(p.bytes[payloadEnd:payloadEnd+4], v)
-	*(*uint32)(unsafe.Pointer(&p.bytes[0])) += 4
-}
-
-// PopUint32 pops one uint32 from the end of payload
-func (p *Packet) PopUint32() (v uint32) {
-	payloadEnd := _PREPAYLOAD_SIZE + p.GetPayloadLen()
-	v = packetEndian.Uint32(p.bytes[payloadEnd-4 : payloadEnd])
-	*(*uint32)(unsafe.Pointer(&p.bytes[0])) -= 4
-	return
+	(*pktconn.Packet)(p).WriteUint32(v)
 }
 
 // AppendUint64 appends one uint64 to the end of payload
 func (p *Packet) AppendUint64(v uint64) {
-	p.AssureCapacity(8)
-	payloadEnd := _PREPAYLOAD_SIZE + p.GetPayloadLen()
-	packetEndian.PutUint64(p.bytes[payloadEnd:payloadEnd+8], v)
-	*(*uint32)(unsafe.Pointer(&p.bytes[0])) += 8
-}
-
-// PackFloat32 packs float32 in specified byte order
-func PackFloat32(order binary.ByteOrder, b []byte, f float32) {
-	fi := *(*uint32)(unsafe.Pointer(&f)) // convert bits from float32 to uint32
-	order.PutUint32(b, fi)
+	(*pktconn.Packet)(p).WriteUint64(v)
 }
 
 // UnpackFloat32 unpacks float32 in specified byte order
@@ -283,80 +87,57 @@ func UnpackFloat32(order binary.ByteOrder, b []byte) (f float32) {
 
 // AppendFloat32 appends one float32 to the end of payload
 func (p *Packet) AppendFloat32(f float32) {
-	p.AppendUint32(*(*uint32)(unsafe.Pointer(&f)))
+	(*pktconn.Packet)(p).WriteFloat32(f)
 }
 
 // ReadFloat32 reads one float32 from the beginning of unread payload
 func (p *Packet) ReadFloat32() float32 {
-	v := p.ReadUint32()
-	return *(*float32)(unsafe.Pointer(&v))
+	return (*pktconn.Packet)(p).ReadFloat32()
 }
 
 // AppendFloat64 appends one float64 to the end of payload
 func (p *Packet) AppendFloat64(f float64) {
-	p.AppendUint64(*(*uint64)(unsafe.Pointer(&f)))
+	(*pktconn.Packet)(p).WriteFloat64(f)
 }
 
 // ReadFloat64 reads one float64 from the beginning of unread payload
 func (p *Packet) ReadFloat64() float64 {
-	v := p.ReadUint64()
-	return *(*float64)(unsafe.Pointer(&v))
+	return (*pktconn.Packet)(p).ReadFloat64()
 }
 
 // AppendBytes appends slice of bytes to the end of payload
 func (p *Packet) AppendBytes(v []byte) {
-	bytesLen := uint32(len(v))
-	p.AssureCapacity(bytesLen)
-	payloadEnd := _PREPAYLOAD_SIZE + p.GetPayloadLen()
-	copy(p.bytes[payloadEnd:payloadEnd+bytesLen], v)
-	*(*uint32)(unsafe.Pointer(&p.bytes[0])) += bytesLen
+	(*pktconn.Packet)(p).WriteBytes(v)
 }
 
 // AppendVarStr appends a varsize string to the end of payload
 func (p *Packet) AppendVarStr(s string) {
-	p.AppendVarBytes([]byte(s))
+	(*pktconn.Packet)(p).WriteVarStrI(s)
 }
 
 // AppendVarBytes appends varsize bytes to the end of payload
 func (p *Packet) AppendVarBytes(v []byte) {
-	p.AppendUint32(uint32(len(v)))
-	p.AppendBytes(v)
+	(*pktconn.Packet)(p).WriteVarBytesI(v)
 }
 
 // ReadUint16 reads one uint16 from the beginning of unread payload
 func (p *Packet) ReadUint16() (v uint16) {
-	pos := p.readCursor + _PREPAYLOAD_SIZE
-	v = packetEndian.Uint16(p.bytes[pos : pos+2])
-	p.readCursor += 2
-	return
+	return (*pktconn.Packet)(p).ReadUint16()
 }
 
 // ReadUint32 reads one uint32 from the beginning of unread payload
 func (p *Packet) ReadUint32() (v uint32) {
-	pos := p.readCursor + _PREPAYLOAD_SIZE
-	v = packetEndian.Uint32(p.bytes[pos : pos+4])
-	p.readCursor += 4
-	return
+	return (*pktconn.Packet)(p).ReadUint32()
 }
 
 // ReadUint64 reads one uint64 from the beginning of unread payload
 func (p *Packet) ReadUint64() (v uint64) {
-	pos := p.readCursor + _PREPAYLOAD_SIZE
-	v = packetEndian.Uint64(p.bytes[pos : pos+8])
-	p.readCursor += 8
-	return
+	return (*pktconn.Packet)(p).ReadUint64()
 }
 
 // ReadBytes reads bytes from the beginning of unread payload
 func (p *Packet) ReadBytes(size uint32) []byte {
-	pos := p.readCursor + _PREPAYLOAD_SIZE
-	if pos > uint32(len(p.bytes)) || pos+size > uint32(len(p.bytes)) {
-		gwlog.Panicf("Packet %p bytes is %d, but reading %d+%d", p, len(p.bytes), pos, size)
-	}
-
-	bytes := p.bytes[pos : pos+size] // bytes are not copied
-	p.readCursor += size
-	return bytes
+	return (*pktconn.Packet)(p).ReadBytes(int(size))
 }
 
 // AppendEntityID appends one Entity ID to the end of payload
@@ -493,11 +274,14 @@ func (p *Packet) ReadEntityIDSet() common.EntityIDSet {
 
 // GetPayloadLen returns the payload length
 func (p *Packet) GetPayloadLen() uint32 {
-	return *(*uint32)(unsafe.Pointer(&p.bytes[0]))
+	return (*pktconn.Packet)(p).GetPayloadLen()
 }
 
 // SetPayloadLen sets the payload l
 func (p *Packet) SetPayloadLen(plen uint32) {
-	pplen := (*uint32)(unsafe.Pointer(&p.bytes[0]))
-	*pplen = plen
+	(*pktconn.Packet)(p).SetPayloadLen(plen)
+}
+
+func (p *Packet) Retain() {
+	(*pktconn.Packet)(p).Retain()
 }

--- a/engine/netutil/PacketConnection.go
+++ b/engine/netutil/PacketConnection.go
@@ -1,209 +1,50 @@
 package netutil
 
 import (
+	"context"
 	"fmt"
+	"github.com/xiaonanln/pktconn"
 	"net"
-
-	"encoding/binary"
-
-	"sync"
-
-	"time"
-
-	"sync/atomic"
-
-	"github.com/pkg/errors"
-	"github.com/xiaonanln/goworld/engine/consts"
-	"github.com/xiaonanln/goworld/engine/gwioutil"
-	"github.com/xiaonanln/goworld/engine/gwlog"
-	"github.com/xiaonanln/goworld/engine/opmon"
 )
-
-const (
-	_MAX_PACKET_SIZE    = 25 * 1024 * 1024 // _MAX_PACKET_SIZE is the max size limit of packets in packet connections
-	_SIZE_FIELD_SIZE    = 4                // _SIZE_FIELD_SIZE is the packet size field (uint32) size
-	_PREPAYLOAD_SIZE    = _SIZE_FIELD_SIZE
-	_MAX_PAYLOAD_LENGTH = _MAX_PACKET_SIZE - _PREPAYLOAD_SIZE
-)
-
-var (
-	// NETWORK_ENDIAN is the network Endian of connections
-	NETWORK_ENDIAN = binary.LittleEndian
-	errRecvAgain   = _ErrRecvAgain{}
-)
-
-type _ErrRecvAgain struct{}
-
-func (err _ErrRecvAgain) Error() string {
-	return "recv again"
-}
-
-func (err _ErrRecvAgain) Temporary() bool {
-	return true
-}
-
-func (err _ErrRecvAgain) Timeout() bool {
-	return true
-}
 
 // PacketConnection is a connection that send and receive data packets upon a network stream connection
-type PacketConnection struct {
-	conn               Connection
-	pendingPackets     []*Packet
-	pendingPacketsLock sync.Mutex
-
-	// buffers and infos for receiving a packet
-	payloadLenBuf         [_SIZE_FIELD_SIZE]byte
-	payloadLenBytesRecved int
-	recvTotalPayloadLen   uint32
-	recvedPayloadLen      uint32
-	recvingPacket         *Packet
-}
+type PacketConnection pktconn.PacketConn
 
 // NewPacketConnection creates a packet connection based on network connection
-func NewPacketConnection(conn Connection) *PacketConnection {
-	pc := &PacketConnection{
-		conn: conn,
-	}
-
-	return pc
+func NewPacketConnection(conn Connection, tag interface{}) *PacketConnection {
+	config := pktconn.DefaultConfig()
+	config.Tag = tag
+	return (*PacketConnection)(pktconn.NewPacketConnWithConfig(context.TODO(), conn, config))
 }
 
 // NewPacket allocates a new packet (usually for sending)
 func (pc *PacketConnection) NewPacket() *Packet {
-	return allocPacket()
+	return NewPacket()
 }
 
 // SendPacket send packets to remote
-func (pc *PacketConnection) SendPacket(packet *Packet) error {
-	if consts.DEBUG_PACKETS {
-		gwlog.Debugf("%s SEND PACKET %p: msgtype=%v, payload(%d)=%v", pc, packet,
-			packetEndian.Uint16(packet.bytes[_PREPAYLOAD_SIZE:_PREPAYLOAD_SIZE+2]),
-			packet.GetPayloadLen(),
-			packet.bytes[_PREPAYLOAD_SIZE+2:_PREPAYLOAD_SIZE+packet.GetPayloadLen()])
-	}
-	if atomic.LoadInt64(&packet.refcount) <= 0 {
-		gwlog.Panicf("sending packet with refcount=%d", packet.refcount)
-	}
-
-	packet.AddRefCount(1)
-	pc.pendingPacketsLock.Lock()
-	pc.pendingPackets = append(pc.pendingPackets, packet)
-	pc.pendingPacketsLock.Unlock()
-	return nil
-}
-
-// Flush connection writes
-func (pc *PacketConnection) Flush(reason string) (err error) {
-	pc.pendingPacketsLock.Lock()
-	if len(pc.pendingPackets) == 0 { // no packets to send, common to happen, so handle efficiently
-		pc.pendingPacketsLock.Unlock()
-		return
-	}
-	packets := make([]*Packet, 0, len(pc.pendingPackets))
-	packets, pc.pendingPackets = pc.pendingPackets, packets
-	pc.pendingPacketsLock.Unlock()
-
-	// flush should only be called in one goroutine
-	op := opmon.StartOperation("FlushPackets-" + reason)
-	defer op.Finish(time.Millisecond * 300)
-
-	//var cw *flate.Writer
-
-	if len(packets) == 1 {
-		// only 1 packet to send, just send it directly, no need to use send buffer
-		packet := packets[0]
-
-		err = gwioutil.WriteAll(pc.conn, packet.data())
-		packet.Release()
-		if err == nil {
-			err = pc.conn.Flush()
-		}
-		return
-	}
-
-	for _, packet := range packets {
-		gwioutil.WriteAll(pc.conn, packet.data())
-		packet.Release()
-	}
-
-	// now we send all data in the send buffer
-	if err == nil {
-		err = pc.conn.Flush()
-	}
-	return
-}
-
-// SetRecvDeadline sets the receive deadline
-func (pc *PacketConnection) SetRecvDeadline(deadline time.Time) error {
-	return pc.conn.SetReadDeadline(deadline)
+func (pc *PacketConnection) SendPacket(packet *Packet) {
+	(*pktconn.PacketConn)(pc).Send((*pktconn.Packet)(packet))
 }
 
 // RecvPacket receives the next packet
-func (pc *PacketConnection) RecvPacket() (*Packet, error) {
-	if pc.payloadLenBytesRecved < _SIZE_FIELD_SIZE {
-		// receive more of payload len bytes
-		n, err := pc.conn.Read(pc.payloadLenBuf[pc.payloadLenBytesRecved:])
-		pc.payloadLenBytesRecved += n
-		if pc.payloadLenBytesRecved < _SIZE_FIELD_SIZE {
-			if err == nil {
-				err = errRecvAgain
-			}
-			return nil, err // packet not finished yet
-		}
-
-		pc.recvTotalPayloadLen = NETWORK_ENDIAN.Uint32(pc.payloadLenBuf[:])
-
-		if pc.recvTotalPayloadLen == 0 || pc.recvTotalPayloadLen > _MAX_PAYLOAD_LENGTH {
-			err := errors.Errorf("invalid payload length: %v", pc.recvTotalPayloadLen)
-			pc.resetRecvStates()
-			pc.Close()
-			return nil, err
-		}
-
-		pc.recvedPayloadLen = 0
-		pc.recvingPacket = NewPacket()
-		pc.recvingPacket.AssureCapacity(pc.recvTotalPayloadLen)
-	}
-
-	// now all bytes of payload len is received, start receiving payload
-	n, err := pc.conn.Read(pc.recvingPacket.bytes[_PREPAYLOAD_SIZE+pc.recvedPayloadLen : _PREPAYLOAD_SIZE+pc.recvTotalPayloadLen])
-	pc.recvedPayloadLen += uint32(n)
-
-	if pc.recvedPayloadLen == pc.recvTotalPayloadLen {
-		// full packet received, return the packet
-		packet := pc.recvingPacket
-		packet.SetPayloadLen(pc.recvTotalPayloadLen)
-		pc.resetRecvStates()
-
-		return packet, nil
-	}
-
-	if err == nil {
-		err = errRecvAgain
-	}
-	return nil, err
-}
-func (pc *PacketConnection) resetRecvStates() {
-	pc.payloadLenBytesRecved = 0
-	pc.recvTotalPayloadLen = 0
-	pc.recvedPayloadLen = 0
-	pc.recvingPacket = nil
+func (pc *PacketConnection) RecvChan(recvChan chan *pktconn.Packet) error {
+	return (*pktconn.PacketConn)(pc).RecvChan(recvChan)
 }
 
 // Close the connection
 func (pc *PacketConnection) Close() error {
-	return pc.conn.Close()
+	return (*pktconn.PacketConn)(pc).Close()
 }
 
 // RemoteAddr return the remote address
 func (pc *PacketConnection) RemoteAddr() net.Addr {
-	return pc.conn.RemoteAddr()
+	return (*pktconn.PacketConn)(pc).RemoteAddr()
 }
 
 // LocalAddr returns the local address
 func (pc *PacketConnection) LocalAddr() net.Addr {
-	return pc.conn.LocalAddr()
+	return (*pktconn.PacketConn)(pc).LocalAddr()
 }
 
 func (pc *PacketConnection) String() string {

--- a/engine/netutil/netutil.go
+++ b/engine/netutil/netutil.go
@@ -1,12 +1,18 @@
 package netutil
 
 import (
+	"encoding/binary"
 	"io"
 	"net"
 
 	"unsafe"
 
 	"github.com/pkg/errors"
+)
+
+var (
+	// NETWORK_ENDIAN is the network Endian of connections
+	NETWORK_ENDIAN = binary.LittleEndian
 )
 
 // IsConnectionError check if the error is a connection error (close)

--- a/engine/netutil/netutil_test.go
+++ b/engine/netutil/netutil_test.go
@@ -2,10 +2,7 @@ package netutil
 
 import (
 	"net"
-	"testing"
 	"time"
-
-	"math/rand"
 
 	"fmt"
 
@@ -42,42 +39,4 @@ func init() {
 		ServeTCP(fmt.Sprintf("localhost:%d", PORT), &testEchoTcpServer{})
 	}()
 	time.Sleep(time.Millisecond * 200)
-}
-
-func TestPacketConnection(t *testing.T) {
-
-	_conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", PORT))
-	if err != nil {
-		t.Errorf("connect error: %s", err)
-	}
-
-	conn := NewPacketConnection(NetConn{_conn})
-
-	for i := 0; i < 10; i++ {
-		var PAYLOAD_LEN uint32 = uint32(rand.Intn(4096 + 1))
-		gwlog.Infof("Testing with payload %v", PAYLOAD_LEN)
-
-		packet := conn.NewPacket()
-		for j := uint32(0); j < PAYLOAD_LEN; j++ {
-			packet.AppendByte(byte(rand.Intn(256)))
-		}
-		if packet.GetPayloadLen() != PAYLOAD_LEN {
-			t.Errorf("payload should be %d, but is %d", PAYLOAD_LEN, packet.GetPayloadLen())
-		}
-		conn.SendPacket(packet)
-		conn.Flush("Test")
-		recvPacket, err := conn.RecvPacket()
-		if err != nil {
-			t.Error(err)
-		}
-		if packet.GetPayloadLen() != recvPacket.GetPayloadLen() {
-			t.Errorf("send packet len %d, but recv len %d", packet.GetPayloadLen(), recvPacket.GetPayloadLen())
-		}
-		for i := uint32(0); i < packet.GetPayloadLen(); i++ {
-			if packet.Payload()[i] != recvPacket.Payload()[i] {
-				t.Errorf("send packet and recv packet mismatch on byte index %d", i)
-			}
-		}
-	}
-
 }

--- a/engine/proto/GoWorldConnection.go
+++ b/engine/proto/GoWorldConnection.go
@@ -1,14 +1,11 @@
 package proto
 
 import (
+	"github.com/xiaonanln/pktconn"
 	"net"
-
-	"time"
 
 	"github.com/xiaonanln/go-xnsyncutil/xnsyncutil"
 	"github.com/xiaonanln/goworld/engine/common"
-	"github.com/xiaonanln/goworld/engine/consts"
-	"github.com/xiaonanln/goworld/engine/gwlog"
 	"github.com/xiaonanln/goworld/engine/netutil"
 )
 
@@ -20,15 +17,15 @@ type GoWorldConnection struct {
 }
 
 // NewGoWorldConnection creates a GoWorldConnection using network connection
-func NewGoWorldConnection(conn netutil.Connection) *GoWorldConnection {
+func NewGoWorldConnection(conn netutil.Connection, tag interface{}) *GoWorldConnection {
 	return &GoWorldConnection{
-		packetConn: netutil.NewPacketConnection(conn),
+		packetConn: netutil.NewPacketConnection(conn, tag),
 	}
 }
 
 // SendSetGameID sends MT_SET_GAME_ID message
 func (gwc *GoWorldConnection) SendSetGameID(id uint16, isReconnect bool, isRestore bool, isBanBootEntity bool,
-	eids []common.EntityID) error {
+	eids []common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_SET_GAME_ID)
 	packet.AppendUint16(id)
@@ -41,105 +38,105 @@ func (gwc *GoWorldConnection) SendSetGameID(id uint16, isReconnect bool, isResto
 	for _, eid := range eids {
 		packet.AppendEntityID(eid)
 	}
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendSetGateID sends MT_SET_GATE_ID message
-func (gwc *GoWorldConnection) SendSetGateID(id uint16) error {
+func (gwc *GoWorldConnection) SendSetGateID(id uint16) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_SET_GATE_ID)
 	packet.AppendUint16(id)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyCreateEntity sends MT_NOTIFY_CREATE_ENTITY message
-func (gwc *GoWorldConnection) SendNotifyCreateEntity(id common.EntityID) error {
+func (gwc *GoWorldConnection) SendNotifyCreateEntity(id common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_CREATE_ENTITY)
 	packet.AppendEntityID(id)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyDestroyEntity sends MT_NOTIFY_DESTROY_ENTITY message
-func (gwc *GoWorldConnection) SendNotifyDestroyEntity(id common.EntityID) error {
+func (gwc *GoWorldConnection) SendNotifyDestroyEntity(id common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_DESTROY_ENTITY)
 	packet.AppendEntityID(id)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyClientConnected sends MT_NOTIFY_CLIENT_CONNECTED message
-func (gwc *GoWorldConnection) SendNotifyClientConnected(id common.ClientID, bootEid common.EntityID) error {
+func (gwc *GoWorldConnection) SendNotifyClientConnected(id common.ClientID, bootEid common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_CLIENT_CONNECTED)
 	packet.AppendClientID(id)
 	packet.AppendEntityID(bootEid)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyClientDisconnected sends MT_NOTIFY_CLIENT_DISCONNECTED message
-func (gwc *GoWorldConnection) SendNotifyClientDisconnected(id common.ClientID, ownerEntityID common.EntityID) error {
+func (gwc *GoWorldConnection) SendNotifyClientDisconnected(id common.ClientID, ownerEntityID common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_CLIENT_DISCONNECTED)
 	packet.AppendEntityID(ownerEntityID)
 	packet.AppendClientID(id)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendCreateEntitySomewhere sends MT_CREATE_ENTITY_SOMEWHERE message
-func (gwc *GoWorldConnection) SendCreateEntitySomewhere(gameid uint16, entityid common.EntityID, typeName string, data map[string]interface{}) error {
+func (gwc *GoWorldConnection) SendCreateEntitySomewhere(gameid uint16, entityid common.EntityID, typeName string, data map[string]interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_CREATE_ENTITY_SOMEWHERE)
 	packet.AppendUint16(gameid)
 	packet.AppendEntityID(entityid)
 	packet.AppendVarStr(typeName)
 	packet.AppendData(data)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendLoadEntitySomewhere sends MT_LOAD_ENTITY_SOMEWHERE message
-func (gwc *GoWorldConnection) SendLoadEntitySomewhere(typeName string, entityID common.EntityID, gameid uint16) error {
+func (gwc *GoWorldConnection) SendLoadEntitySomewhere(typeName string, entityID common.EntityID, gameid uint16) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_LOAD_ENTITY_SOMEWHERE)
 	packet.AppendUint16(gameid)
 	packet.AppendEntityID(entityID)
 	packet.AppendVarStr(typeName)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendKvregRegister
-func (gwc *GoWorldConnection) SendKvregRegister(srvid string, info string, force bool) error {
+func (gwc *GoWorldConnection) SendKvregRegister(srvid string, info string, force bool) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_KVREG_REGISTER)
 	packet.AppendVarStr(srvid)
 	packet.AppendVarStr(info)
 	packet.AppendBool(force)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendCallEntityMethod sends MT_CALL_ENTITY_METHOD message
-func (gwc *GoWorldConnection) SendCallEntityMethod(id common.EntityID, method string, args []interface{}) error {
+func (gwc *GoWorldConnection) SendCallEntityMethod(id common.EntityID, method string, args []interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_CALL_ENTITY_METHOD)
 	packet.AppendEntityID(id)
 	packet.AppendVarStr(method)
 	packet.AppendArgs(args)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendCallEntityMethodFromClient sends MT_CALL_ENTITY_METHOD_FROM_CLIENT message
-func (gwc *GoWorldConnection) SendCallEntityMethodFromClient(id common.EntityID, method string, args []interface{}) error {
+func (gwc *GoWorldConnection) SendCallEntityMethodFromClient(id common.EntityID, method string, args []interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_CALL_ENTITY_METHOD_FROM_CLIENT)
 	packet.AppendEntityID(id)
 	packet.AppendVarStr(method)
 	packet.AppendArgs(args)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendCreateEntityOnClient sends MT_CREATE_ENTITY_ON_CLIENT message
 func (gwc *GoWorldConnection) SendCreateEntityOnClient(gameid uint16, clientid common.ClientID, typeName string, entityid common.EntityID,
-	isPlayer bool, clientData map[string]interface{}, x, y, z float32, yaw float32) error {
+	isPlayer bool, clientData map[string]interface{}, x, y, z float32, yaw float32) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_CREATE_ENTITY_ON_CLIENT)
 	packet.AppendUint16(gameid)
@@ -152,11 +149,11 @@ func (gwc *GoWorldConnection) SendCreateEntityOnClient(gameid uint16, clientid c
 	packet.AppendFloat32(z)
 	packet.AppendFloat32(yaw)
 	packet.AppendData(clientData)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendSyncPositionYawFromClient sends MT_SYNC_POSITION_YAW_FROM_CLIENT message
-func (gwc *GoWorldConnection) SendSyncPositionYawFromClient(entityID common.EntityID, x, y, z float32, yaw float32) error {
+func (gwc *GoWorldConnection) SendSyncPositionYawFromClient(entityID common.EntityID, x, y, z float32, yaw float32) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_SYNC_POSITION_YAW_FROM_CLIENT)
 	packet.AppendEntityID(entityID)
@@ -164,36 +161,28 @@ func (gwc *GoWorldConnection) SendSyncPositionYawFromClient(entityID common.Enti
 	packet.AppendFloat32(y)
 	packet.AppendFloat32(z)
 	packet.AppendFloat32(yaw)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
-//func (gwc *GoWorldConnection) SendSetClientClientID(clientid common.ClientID) error {
-//	packet := gwc.packetConn.NewPacket()
-//	packet.AppendUint16(MT_SET_CLIENT_CLIENTID)
-//	packet.AppendClientID(clientid)
-//	return gwc.SendPacketRelease(packet)
-//}
-
-func (gwc *GoWorldConnection) SetHeartbeatFromClient() error {
+func (gwc *GoWorldConnection) SetHeartbeatFromClient() {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_HEARTBEAT_FROM_CLIENT)
-	return gwc.SendPacketRelease(packet)
-
+	gwc.SendPacketRelease(packet)
 }
 
 // SendDestroyEntityOnClient sends MT_DESTROY_ENTITY_ON_CLIENT message
-func (gwc *GoWorldConnection) SendDestroyEntityOnClient(gateid uint16, clientid common.ClientID, typeName string, entityid common.EntityID) error {
+func (gwc *GoWorldConnection) SendDestroyEntityOnClient(gateid uint16, clientid common.ClientID, typeName string, entityid common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_DESTROY_ENTITY_ON_CLIENT)
 	packet.AppendUint16(gateid)
 	packet.AppendClientID(clientid)
 	packet.AppendVarStr(typeName)
 	packet.AppendEntityID(entityid)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyMapAttrChangeOnClient sends MT_NOTIFY_MAP_ATTR_CHANGE_ON_CLIENT message
-func (gwc *GoWorldConnection) SendNotifyMapAttrChangeOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, key string, val interface{}) error {
+func (gwc *GoWorldConnection) SendNotifyMapAttrChangeOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, key string, val interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_MAP_ATTR_CHANGE_ON_CLIENT)
 	packet.AppendUint16(gateid)
@@ -202,11 +191,11 @@ func (gwc *GoWorldConnection) SendNotifyMapAttrChangeOnClient(gateid uint16, cli
 	packet.AppendData(path)
 	packet.AppendVarStr(key)
 	packet.AppendData(val)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyMapAttrDelOnClient sends MT_NOTIFY_MAP_ATTR_DEL_ON_CLIENT message
-func (gwc *GoWorldConnection) SendNotifyMapAttrDelOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, key string) error {
+func (gwc *GoWorldConnection) SendNotifyMapAttrDelOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, key string) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_MAP_ATTR_DEL_ON_CLIENT)
 	packet.AppendUint16(gateid)
@@ -214,22 +203,22 @@ func (gwc *GoWorldConnection) SendNotifyMapAttrDelOnClient(gateid uint16, client
 	packet.AppendEntityID(entityid)
 	packet.AppendData(path)
 	packet.AppendVarStr(key)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyMapAttrClearOnClient sends MT_NOTIFY_MAP_ATTR_CLEAR_ON_CLIENT message
-func (gwc *GoWorldConnection) SendNotifyMapAttrClearOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}) error {
+func (gwc *GoWorldConnection) SendNotifyMapAttrClearOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_MAP_ATTR_CLEAR_ON_CLIENT)
 	packet.AppendUint16(gateid)
 	packet.AppendClientID(clientid)
 	packet.AppendEntityID(entityid)
 	packet.AppendData(path)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyListAttrChangeOnClient sends MT_NOTIFY_LIST_ATTR_CHANGE_ON_CLIENT message
-func (gwc *GoWorldConnection) SendNotifyListAttrChangeOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, index uint32, val interface{}) error {
+func (gwc *GoWorldConnection) SendNotifyListAttrChangeOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, index uint32, val interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_LIST_ATTR_CHANGE_ON_CLIENT)
 	packet.AppendUint16(gateid)
@@ -238,22 +227,22 @@ func (gwc *GoWorldConnection) SendNotifyListAttrChangeOnClient(gateid uint16, cl
 	packet.AppendData(path)
 	packet.AppendUint32(index)
 	packet.AppendData(val)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyListAttrPopOnClient sends MT_NOTIFY_LIST_ATTR_POP_ON_CLIENT message
-func (gwc *GoWorldConnection) SendNotifyListAttrPopOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}) error {
+func (gwc *GoWorldConnection) SendNotifyListAttrPopOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_LIST_ATTR_POP_ON_CLIENT)
 	packet.AppendUint16(gateid)
 	packet.AppendClientID(clientid)
 	packet.AppendEntityID(entityid)
 	packet.AppendData(path)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendNotifyListAttrAppendOnClient sends MT_NOTIFY_LIST_ATTR_APPEND_ON_CLIENT message
-func (gwc *GoWorldConnection) SendNotifyListAttrAppendOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, val interface{}) error {
+func (gwc *GoWorldConnection) SendNotifyListAttrAppendOnClient(gateid uint16, clientid common.ClientID, entityid common.EntityID, path []interface{}, val interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_NOTIFY_LIST_ATTR_APPEND_ON_CLIENT)
 	packet.AppendUint16(gateid)
@@ -261,11 +250,11 @@ func (gwc *GoWorldConnection) SendNotifyListAttrAppendOnClient(gateid uint16, cl
 	packet.AppendEntityID(entityid)
 	packet.AppendData(path)
 	packet.AppendData(val)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendCallEntityMethodOnClient sends MT_CALL_ENTITY_METHOD_ON_CLIENT message
-func (gwc *GoWorldConnection) SendCallEntityMethodOnClient(gateid uint16, clientid common.ClientID, entityID common.EntityID, method string, args []interface{}) (err error) {
+func (gwc *GoWorldConnection) SendCallEntityMethodOnClient(gateid uint16, clientid common.ClientID, entityID common.EntityID, method string, args []interface{}) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_CALL_ENTITY_METHOD_ON_CLIENT)
 	packet.AppendUint16(gateid)
@@ -273,27 +262,27 @@ func (gwc *GoWorldConnection) SendCallEntityMethodOnClient(gateid uint16, client
 	packet.AppendEntityID(entityID)
 	packet.AppendVarStr(method)
 	packet.AppendArgs(args)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendSetClientFilterProp sends MT_SET_CLIENTPROXY_FILTER_PROP message
-func (gwc *GoWorldConnection) SendSetClientFilterProp(gateid uint16, clientid common.ClientID, key, val string) (err error) {
+func (gwc *GoWorldConnection) SendSetClientFilterProp(gateid uint16, clientid common.ClientID, key, val string) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_SET_CLIENTPROXY_FILTER_PROP)
 	packet.AppendUint16(gateid)
 	packet.AppendClientID(clientid)
 	packet.AppendVarStr(key)
 	packet.AppendVarStr(val)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendClearClientFilterProp sends MT_CLEAR_CLIENTPROXY_FILTER_PROPS message
-func (gwc *GoWorldConnection) SendClearClientFilterProp(gateid uint16, clientid common.ClientID) (err error) {
+func (gwc *GoWorldConnection) SendClearClientFilterProp(gateid uint16, clientid common.ClientID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_CLEAR_CLIENTPROXY_FILTER_PROPS)
 	packet.AppendUint16(gateid)
 	packet.AppendClientID(clientid)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendCallFilterClientProxies sends MT_CALL_FILTERED_CLIENTS message
@@ -326,48 +315,41 @@ func AllocGameLBCInfoPacket(lbcinfo GameLBCInfo) *netutil.Packet {
 }
 
 // SendQuerySpaceGameIDForMigrate sends MT_QUERY_SPACE_GAMEID_FOR_MIGRATE message
-func (gwc *GoWorldConnection) SendQuerySpaceGameIDForMigrate(spaceid common.EntityID, entityid common.EntityID) error {
+func (gwc *GoWorldConnection) SendQuerySpaceGameIDForMigrate(spaceid common.EntityID, entityid common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_QUERY_SPACE_GAMEID_FOR_MIGRATE)
 	packet.AppendEntityID(spaceid)
 	packet.AppendEntityID(entityid)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendMigrateRequest sends MT_MIGRATE_REQUEST message
-func (gwc *GoWorldConnection) SendMigrateRequest(entityID common.EntityID, spaceID common.EntityID, spaceGameID uint16) error {
+func (gwc *GoWorldConnection) SendMigrateRequest(entityID common.EntityID, spaceID common.EntityID, spaceGameID uint16) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_MIGRATE_REQUEST)
 	packet.AppendEntityID(entityID)
 	packet.AppendEntityID(spaceID)
 	packet.AppendUint16(spaceGameID)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendCancelMigrate sends MT_CANCEL_MIGRATE message to dispatcher to unblock the entity
-func (gwc *GoWorldConnection) SendCancelMigrate(entityid common.EntityID) error {
+func (gwc *GoWorldConnection) SendCancelMigrate(entityid common.EntityID) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_CANCEL_MIGRATE)
 	packet.AppendEntityID(entityid)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
 
 // SendRealMigrate sends MT_REAL_MIGRATE message
-func (gwc *GoWorldConnection) SendRealMigrate(eid common.EntityID, targetGame uint16, data []byte) error {
+func (gwc *GoWorldConnection) SendRealMigrate(eid common.EntityID, targetGame uint16, data []byte) {
 	packet := gwc.packetConn.NewPacket()
 	packet.AppendUint16(MT_REAL_MIGRATE)
 	packet.AppendEntityID(eid)
 	packet.AppendUint16(targetGame)
 	packet.AppendVarBytes(data)
-	return gwc.SendPacketRelease(packet)
+	gwc.SendPacketRelease(packet)
 }
-
-//// SendStartFreezeGame sends MT_START_FREEZE_GAME message
-//func (gwc *GoWorldConnection) SendStartFreezeGame(gameid uint16) error {
-//	packet := gwc.packetConn.NewPacket()
-//	packet.AppendUint16(MT_START_FREEZE_GAME)
-//	return gwc.SendPacketRelease(packet)
-//}
 
 func AllocStartFreezeGamePacket() *netutil.Packet {
 	packet := netutil.NewPacket()
@@ -395,7 +377,7 @@ func MakeNotifyDeploymentReadyPacket() *netutil.Packet {
 	return pkt
 }
 
-func (gwc *GoWorldConnection) SendSetGameIDAck(dispid uint16, isDeploymentReady bool, connectedGameIDs []uint16, rejectEntities []common.EntityID, kvregRegisterMap map[string]string) error {
+func (gwc *GoWorldConnection) SendSetGameIDAck(dispid uint16, isDeploymentReady bool, connectedGameIDs []uint16, rejectEntities []common.EntityID, kvregRegisterMap map[string]string) {
 	pkt := netutil.NewPacket()
 	pkt.AppendUint16(MT_SET_GAME_ID_ACK)
 	pkt.AppendUint16(dispid)
@@ -413,61 +395,18 @@ func (gwc *GoWorldConnection) SendSetGameIDAck(dispid uint16, isDeploymentReady 
 	}
 	// put all services to the packet
 	pkt.AppendMapStringString(kvregRegisterMap)
-	return gwc.SendPacketRelease(pkt)
+	gwc.SendPacketRelease(pkt)
 }
 
 // SendPacket send a packet to remote
-func (gwc *GoWorldConnection) SendPacket(packet *netutil.Packet) error {
-	return gwc.packetConn.SendPacket(packet)
+func (gwc *GoWorldConnection) SendPacket(packet *netutil.Packet) {
+	gwc.packetConn.SendPacket(packet)
 }
 
 // SendPacketRelease send a packet to remote and then release the packet
-func (gwc *GoWorldConnection) SendPacketRelease(packet *netutil.Packet) error {
-	err := gwc.packetConn.SendPacket(packet)
+func (gwc *GoWorldConnection) SendPacketRelease(packet *netutil.Packet) {
+	gwc.packetConn.SendPacket(packet)
 	packet.Release()
-	return err
-}
-
-// Flush connection writes
-func (gwc *GoWorldConnection) Flush(reason string) error {
-	return gwc.packetConn.Flush(reason)
-}
-
-// SetAutoFlush starts a goroutine to flush connection writes at some specified interval
-func (gwc *GoWorldConnection) SetAutoFlush(interval time.Duration) {
-	if gwc.autoFlushing {
-		gwlog.Panicf("%s.SetAutoFlush: already auto flushing!", gwc)
-	}
-	gwc.autoFlushing = true
-	go func() {
-		//defer gwlog.Debugf("%s: auto flush routine quited", gwc)
-		for !gwc.IsClosed() {
-			time.Sleep(interval)
-			err := gwc.Flush("AutoFlush")
-			if err != nil {
-				break
-			}
-		}
-	}()
-}
-
-// Recv receives the next packet and retrive the message type
-func (gwc *GoWorldConnection) Recv(msgtype *MsgType) (*netutil.Packet, error) {
-	pkt, err := gwc.packetConn.RecvPacket()
-	if err != nil {
-		return nil, err
-	}
-
-	*msgtype = MsgType(pkt.ReadUint16())
-	if consts.DEBUG_PACKETS {
-		gwlog.Infof("%s: Recv msgtype=%v, payload size=%d", gwc, *msgtype, pkt.GetPayloadLen())
-	}
-	return pkt, nil
-}
-
-// SetRecvDeadline set receive deadline
-func (gwc *GoWorldConnection) SetRecvDeadline(deadline time.Time) error {
-	return gwc.packetConn.SetRecvDeadline(deadline)
 }
 
 // Close this connection
@@ -493,4 +432,8 @@ func (gwc *GoWorldConnection) LocalAddr() net.Addr {
 
 func (gwc *GoWorldConnection) String() string {
 	return gwc.packetConn.String()
+}
+
+func (gwc *GoWorldConnection) RecvChan(recvChan chan *pktconn.Packet) error {
+	return gwc.packetConn.RecvChan(recvChan)
 }

--- a/engine/proto/proto.go
+++ b/engine/proto/proto.go
@@ -5,16 +5,10 @@ import (
 
 	"github.com/xiaonanln/goworld/engine/common"
 	"github.com/xiaonanln/goworld/engine/gwlog"
-	"github.com/xiaonanln/goworld/engine/netutil"
 )
 
 // MsgType is the type of message types
 type MsgType uint16
-
-type Message struct {
-	MsgType MsgType
-	Packet  *netutil.Packet
-}
 
 const (
 	// MT_INVALID is the invalid message type

--- a/examples/test_client/ClientBot.go
+++ b/examples/test_client/ClientBot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/xiaonanln/netconnutil"
+	"github.com/xiaonanln/pktconn"
 	"net"
 	"sync"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/xiaonanln/goworld/engine/config"
 	"github.com/xiaonanln/goworld/engine/consts"
 	"github.com/xiaonanln/goworld/engine/entity"
-	"github.com/xiaonanln/goworld/engine/gwioutil"
 	"github.com/xiaonanln/goworld/engine/gwlog"
 	"github.com/xiaonanln/goworld/engine/netutil"
 	"github.com/xiaonanln/goworld/engine/post"
@@ -54,7 +54,7 @@ type ClientBot struct {
 	useKCP             bool
 	useWebSocket       bool
 	noEntitySync       bool
-	packetQueue        chan proto.Message
+	packetQueue        chan *pktconn.Packet
 }
 
 func newClientBot(id int, useWebSocket bool, useKCP bool, noEntitySync bool, waiter *sync.WaitGroup, waitAllConnected *sync.WaitGroup) *ClientBot {
@@ -66,7 +66,7 @@ func newClientBot(id int, useWebSocket bool, useKCP bool, noEntitySync bool, wai
 		useKCP:           useKCP,
 		useWebSocket:     useWebSocket,
 		noEntitySync:     noEntitySync,
-		packetQueue:      make(chan proto.Message),
+		packetQueue:      make(chan *pktconn.Packet),
 	}
 }
 
@@ -107,7 +107,7 @@ func (bot *ClientBot) run() {
 		conn = netconnutil.NewSnappyConn(conn)
 	}
 	conn = netconnutil.NewBufferedConn(conn, consts.BUFFERED_READ_BUFFSIZE, consts.BUFFERED_WRITE_BUFFSIZE)
-	bot.conn = proto.NewGoWorldConnection(conn)
+	bot.conn = proto.NewGoWorldConnection(conn, nil)
 	defer bot.conn.Close()
 
 	if bot.useKCP {
@@ -193,29 +193,18 @@ func (bot *ClientBot) connectServerByWebsocket(cfg *config.GateConfig) (net.Conn
 }
 
 func (bot *ClientBot) recvLoop() {
-	var msgtype proto.MsgType
-
-	for {
-		pkt, err := bot.conn.Recv(&msgtype)
-		if pkt != nil {
-			//fmt.Fprintf(os.Stderr, "P")
-			bot.packetQueue <- proto.Message{msgtype, pkt}
-		} else if err != nil && !gwioutil.IsTimeoutError(err) {
-			// bad error
-			Errorf("%s: client recv packet failed: %v", bot, err)
-			break
-		}
-	}
+	err := bot.conn.RecvChan(bot.packetQueue)
+	gwlog.Error(err)
 }
 
 func (bot *ClientBot) loop() {
 	ticker := time.Tick(time.Millisecond * 100)
 	for {
 		select {
-		case item := <-bot.packetQueue:
-			//fmt.Fprintf(os.Stderr, "p")
-			bot.handlePacket(item.MsgType, item.Packet)
-			item.Packet.Release()
+		case _pkt := <-bot.packetQueue:
+			pkt := (*netutil.Packet)(_pkt)
+			bot.handlePacket(pkt)
+			pkt.Release()
 			break
 		case <-ticker:
 			//fmt.Fprintf(os.Stderr, "|")
@@ -238,14 +227,13 @@ func (bot *ClientBot) loop() {
 				}
 
 			}
-			bot.conn.Flush("ClientBot")
 			post.Tick()
 			break
 		}
 	}
 }
 
-func (bot *ClientBot) handlePacket(msgtype proto.MsgType, packet *netutil.Packet) {
+func (bot *ClientBot) handlePacket(packet *netutil.Packet) {
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -256,7 +244,7 @@ func (bot *ClientBot) handlePacket(msgtype proto.MsgType, packet *netutil.Packet
 	bot.Lock()
 	defer bot.Unlock()
 
-	//gwlog.Infof("client handle packet: msgtype=%v, payload=%v", msgtype, packet.Payload())
+	msgtype := packet.ReadUint16()
 
 	if msgtype >= proto.MT_REDIRECT_TO_GATEPROXY_MSG_TYPE_START && msgtype <= proto.MT_REDIRECT_TO_GATEPROXY_MSG_TYPE_STOP {
 		_ = packet.ReadUint16()
@@ -372,9 +360,6 @@ func (bot *ClientBot) handlePacket(msgtype proto.MsgType, packet *netutil.Packet
 			bot.updateEntityPosition(entityID, entity.Vector3{x, y, z})
 			bot.updateEntityYaw(entityID, yaw)
 		}
-		//} else if msgtype == proto.MT_SET_CLIENT_CLIENTID {
-		//	clientid := packet.ReadClientID()
-		//	bot.setClientID(clientid)
 	} else {
 		gwlog.Panicf("unknown msgtype: %v", msgtype)
 	}

--- a/go.mod
+++ b/go.mod
@@ -27,13 +27,14 @@ require (
 	github.com/xiaonanln/go-trie-tst v0.0.0-20171018095208-5b9678d55438
 	github.com/xiaonanln/go-xnsyncutil v0.0.5
 	github.com/xiaonanln/goTimer v0.0.3
-	github.com/xiaonanln/netconnutil v0.0.0-20200208154411-dc274e29fea7
-	github.com/xiaonanln/pktconn v0.0.0-20200206154948-4ca31f7eb154 // indirect
+	github.com/xiaonanln/netconnutil v0.0.0-20200905060227-8faf06e9a365
+	github.com/xiaonanln/pktconn v0.0.0-20200905130536-8a9529b7c220
 	github.com/xiaonanln/tickchan v0.0.0-20181130012730-45de2aab1755 // indirect
 	github.com/xiaonanln/typeconv v0.0.4
 	github.com/xtaci/kcp-go v5.4.19+incompatible
 	github.com/xtaci/lossyconn v0.0.0-20190602105132-8df528c0c9ae // indirect
 	go.uber.org/zap v1.13.0
+	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933
 	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
 	google.golang.org/appengine v1.6.5 // indirect


### PR DESCRIPTION
[`pktconn`](https://github.com/xiaonanln/pktconn) outperforms the existing `PacketConnection` implementation in `GoWorld` in both throughput and latency and is better tested. 

**Networking latency reduced from ~100ms to ~20ms while using `pktconn`:**

- Using `pktconn`
```
===============================================================================
> DoEnterRandomSpace               *12 AVG 31.679474ms RANGE 36.578197ms ~ 39.285657ms
> DoSayInWorldChannel              *6 AVG 18.169696ms RANGE 16.115951ms ~ 22.609393ms
> DoSayInProfChannel               *2 AVG 18.730558ms RANGE 18.204597ms ~ 19.25652ms
> DoTestComplexAttr                *7 AVG 15.939933ms RANGE 17.665885ms ~ 19.198419ms
> DoTestCallAll                    *5 AVG 30.375302ms RANGE 27.741105ms ~ 38.140432ms
> DoTestAOI                        *6 AVG 13.880952ms RANGE 13.166287ms ~ 16.352856ms
> DoTestListField                  *8 AVG 15.465175ms RANGE 14.520017ms ~ 21.657073ms
> DoEnterRandomNilSpace            *5 AVG 19.588687ms RANGE 11.402049ms ~ 24.656038ms
===============================================================================
```

- Original:
```
===============================================================================
> DoTestCallAll                    *4 AVG 195.988074ms RANGE 194.515821ms ~ 197.869241ms
> DoTestAOI                        *5 AVG 94.045686ms RANGE 90.103806ms ~ 101.137198ms
> DoTestListField                  *9 AVG 93.991133ms RANGE 90.080405ms ~ 99.492241ms
> DoTestComplexAttr                *8 AVG 97.600485ms RANGE 92.912506ms ~ 113.727948ms
> DoEnterRandomNilSpace            *9 AVG 106.968017ms RANGE 90.091706ms ~ 126.201891ms
> DoSayInProfChannel               *3 AVG 88.898896ms RANGE 90.202709ms ~ 90.584523ms
> DoEnterRandomSpace               *19 AVG 113.986718ms RANGE 119.16004ms ~ 130.237434ms
> DoSayInWorldChannel              *6 AVG 89.768127ms RANGE 89.412981ms ~ 94.405859ms
===============================================================================
```