### PR TITLE
Fixed a bug with arithmetic symbols in Vector3.go

### DIFF
--- a/engine/entity/Vector3.go
+++ b/engine/entity/Vector3.go
@@ -62,7 +62,7 @@ func (dir Vector3) DirToYaw() Yaw {
 }
 
 func (p *Vector3) Normalize() {
-	d := Coord(math.Sqrt(float64(p.X*p.X + p.Y + p.Y + p.Z*p.Z)))
+	d := Coord(math.Sqrt(float64(p.X*p.X + p.Y*p.Y + p.Z*p.Z)))
 	if d == 0 {
 		return
 	}


### PR DESCRIPTION
The multiplication sign in the Normalize() function is written as a plus sign.

Now it is `(p.X*p.X + p.Y + p.Y + p.Z*p.Z)` and it should be `(p.X*p.X + p.Y*p.Y + p.Z*p.Z)` .